### PR TITLE
[WIP] add function parse_bibtex_ordered

### DIFF
--- a/src/BibTeX.jl
+++ b/src/BibTeX.jl
@@ -97,7 +97,6 @@ field!(parser, dict) = begin
     expect(parser, token, "}")
 end
 
-export parse_bibtex
 """
     parse_bibtex(text)
 
@@ -171,7 +170,7 @@ function parse_bibtex(text)
 end
 
 function parse_bibtex_ordered(text)
-    ordered = []
+    ordered = Array{Dict{String, Dict{String,String}}, 1}()
     parser = parse_text(text)
     token = next_token_default!(parser)
     preamble = ""
@@ -190,7 +189,7 @@ function parse_bibtex_ordered(text)
                     expect!(parser, ",")
                     field!(parser, dict)
                     parser.records[id] = dict
-                    push!(ordered, Dict(id => dict))
+                    push!(ordered, Dict(string(id) => dict))
                     
                 end
             end
@@ -200,4 +199,8 @@ function parse_bibtex_ordered(text)
     preamble, ordered
 end
     
+export parse_bibtex_ordered
+export parse_bibtex
+
+
 end

--- a/src/BibTeX.jl
+++ b/src/BibTeX.jl
@@ -143,7 +143,7 @@ ERROR: Expected { on line 1
 [...]
 ```
 """
-parse_bibtex(text) = begin
+function parse_bibtex(text)
     parser = parse_text(text)
     token = next_token_default!(parser)
     preamble = ""
@@ -170,4 +170,34 @@ parse_bibtex(text) = begin
     preamble, parser.records
 end
 
+function parse_bibtex_ordered(text)
+    ordered = []
+    parser = parse_text(text)
+    token = next_token_default!(parser)
+    preamble = ""
+    while token != ""
+        if token == "@"
+            record_type = lowercase(next_token!(parser))
+            if record_type == "preamble"
+                trash, preamble = value!(parser)
+            elseif record_type != "comment"
+                expect!(parser, "{")
+                if record_type == "string"
+                    field!(parser, parser.substitutions)
+                else
+                    id = next_token!(parser)
+                    dict = Dict("type" => record_type)
+                    expect!(parser, ",")
+                    field!(parser, dict)
+                    parser.records[id] = dict
+                    push!(ordered, Dict(id => dict))
+                    
+                end
+            end
+        end
+        token = next_token_default!(parser)
+    end
+    preamble, ordered
+end
+    
 end


### PR DESCRIPTION
Adds a function `parse_bibtex_ordered`, which, instead of returning a Dict of Dicts, returns an Array of Dicts.  This may be useful for determination of primacy in the CITATION.bib file format.